### PR TITLE
Fix frontend API baseURL

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 // Create a single axios instance for all API requests
 export const api = axios.create({
-  baseURL: "/api/routes", // instead of "/api"
+  baseURL: "/api",
   withCredentials: true,
   timeout: 15000
 });


### PR DESCRIPTION
## Summary
- use `/api` as axios baseURL

## Testing
- `grep -n "baseURL" -r frontend/src/services`


------
https://chatgpt.com/codex/tasks/task_e_68663c4fdd3c832cb2c4fff681e5741b