### PR TITLE
Add API route stubs

### DIFF
--- a/core/routes/agents.py
+++ b/core/routes/agents.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/agents/stats")
+async def agent_stats():
+    return {"connected": 0}

--- a/core/routes/auth.py
+++ b/core/routes/auth.py
@@ -1,0 +1,59 @@
+from fastapi import APIRouter, Query
+
+router = APIRouter()
+
+@router.post("/auth/register")
+async def register_user(data: dict):
+    return {"status": "registered", "user": data}
+
+@router.post("/auth/login")
+async def login_user(credentials: dict):
+    return {"id": 1, "username": credentials.get("username"), "role": "user", "token": "fake-token", "pin_verified": True}
+
+@router.post("/auth/logout")
+async def logout_user():
+    return {"status": "logged_out"}
+
+@router.get("/auth/me")
+async def get_profile():
+    return {"id": 1, "username": "demo", "email": "demo@example.com", "role": "user", "verified": True}
+
+@router.post("/auth/refresh")
+async def refresh_token():
+    return {"access_token": "refreshed-token"}
+
+@router.get("/auth/auto_login")
+async def auto_login():
+    return {"username": "demo", "role": "user"}
+
+@router.post("/auth/set_pin")
+async def set_pin(pin: str):
+    return {"success": True, "message": "pin set"}
+
+@router.post("/auth/verify_pin")
+async def verify_pin(pin: str):
+    return {"success": True}
+
+@router.post("/auth/change_pin")
+async def change_pin(old_pin: str, new_pin: str):
+    return {"success": True, "message": "pin changed"}
+
+@router.get("/auth/verify_email")
+async def verify_email(token: str = Query(...)):
+    return {"message": "Email verified"}
+
+@router.get("/auth/status")
+async def auth_status():
+    return {"status": "authenticated", "username": "demo", "role": "user"}
+
+@router.get("/auth/admin_only")
+async def admin_only():
+    return {"message": "admin access granted"}
+
+@router.post("/auth/password-reset/request")
+async def password_reset_request(email: str):
+    return {"message": "Reset email sent"}
+
+@router.post("/auth/password-reset/verify")
+async def password_reset_verify(token: str, new_password: str):
+    return {"message": "Password reset successful"}

--- a/core/routes/database.py
+++ b/core/routes/database.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/connections")
+async def list_connections():
+    return []
+
+@router.post("/connections")
+async def create_connection(data: dict):
+    return {"id": "1", **data}
+
+@router.post("/structure")
+async def db_structure(params: dict):
+    return {"items": []}
+
+@router.get("/database/{database}/schema/{schema}/table/{table}")
+async def get_table_data(database: str, schema: str, table: str):
+    return {"rows": []}
+
+@router.get("/metrics/database")
+async def database_metrics():
+    return {"databaseSize": "0", "tables": 0, "activeConnections": 0, "uptime": "0", "queriesPerSecond": 0, "cacheHitRatio": 0}

--- a/core/routes/feedback.py
+++ b/core/routes/feedback.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post("/feedback/submit")
+async def submit_feedback(data: dict):
+    return {"status": "ok", "id": 1}
+
+@router.get("/feedback/pending")
+async def pending_feedback():
+    return []
+
+@router.post("/feedback/analyze")
+async def analyze_feedback(message: str, feedback_type: str):
+    return {"analysis": {"message": message, "type": feedback_type}}
+
+@router.post("/feedback/approve/{feedback_id}")
+async def approve_feedback(feedback_id: int):
+    return {"status": "approved"}

--- a/core/routes/logs.py
+++ b/core/routes/logs.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/logs/query")
+async def query_logs(q: str | None = None, limit: int = 50, agent: str | None = None, start_time: str | None = None, end_time: str | None = None, level: str | None = None):
+    return []
+
+@router.get("/logs/recent")
+async def recent_logs(limit: int = 5):
+    return []
+
+@router.get("/logs/metrics")
+async def log_metrics():
+    return {"sentiment": {}, "tags": {}, "agents": {}, "errors_last_24h": 0}
+
+@router.post("/logs/flag")
+async def flag_log(log_id: str, reason: str | None = None):
+    return {"status": "flagged"}
+
+@router.post("/logs/save")
+async def save_log(entry: dict):
+    return {"status": "saved"}

--- a/core/routes/mycocore.py
+++ b/core/routes/mycocore.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/mycocore/snapshot")
+async def mycocore_snapshot():
+    return {"status": "ok", "uptime": "0", "memory_usage": 0, "cpu_usage": 0, "agents": [], "safe_mode": False}
+
+@router.get("/mycocore/alerts")
+async def mycocore_alerts():
+    return {"status": "ok", "alerts": [], "timestamp": "now"}
+
+@router.post("/mycocore/safe-mode")
+async def toggle_safe_mode():
+    return {"status": "ok", "safe_mode": "off"}

--- a/core/routes/neuroweave.py
+++ b/core/routes/neuroweave.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post("/neuroweave/ask")
+async def neuroweave_ask(prompt: str):
+    return {"agent": "neuroweave", "response": "answer"}
+
+@router.post("/agent/ask")
+async def neuroweave_tracked(prompt: str):
+    return {"agent": "neuroweave", "response": "answer"}
+
+@router.get("/neuroweave/test")
+async def neuroweave_test():
+    return {"status": "ok", "agent": "neuroweave"}
+
+@router.get("/neuroweave/health")
+async def neuroweave_health():
+    return {"status": "ok"}

--- a/core/routes/plugins.py
+++ b/core/routes/plugins.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/plugins/list")
+async def list_plugins():
+    return {"status": "ok", "plugins": []}
+
+@router.post("/plugins/execute")
+async def execute_plugin(data: dict):
+    return {"status": "ok", "result": None}
+
+@router.post("/plugins/chain")
+async def execute_plugin_chain(data: dict):
+    return {"status": "ok", "results": []}

--- a/core/routes/query.py
+++ b/core/routes/query.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/queries/recent")
+async def recent_queries(limit: int = 10):
+    return []

--- a/core/routes/rootbloom.py
+++ b/core/routes/rootbloom.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post("/rootbloom/generate")
+async def generate_content(prompt: str, context: dict | None = None):
+    return {"agent": "rootbloom", "response": "generated", "timestamp": "now"}
+
+@router.get("/rootbloom/health")
+async def rootbloom_health():
+    return {"status": "ok", "details": {}, "timestamp": "now"}

--- a/core/routes/sporelink.py
+++ b/core/routes/sporelink.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post("/sporelink/analyze")
+async def analyze_market(prompt: str, context: dict | None = None):
+    return {"agent": "sporelink", "response": "analysis", "timestamp": "now"}
+
+@router.get("/sporelink/market/{symbol}")
+async def get_market_data(symbol: str):
+    return {"status": "ok", "data": {}, "cached": False}
+
+@router.get("/sporelink/news")
+async def get_market_news(category: str | None = None, limit: int = 10):
+    return {"status": "ok", "news": [], "cached": False}
+
+@router.get("/sporelink/health")
+async def sporelink_health():
+    return {"status": "ok"}

--- a/core/routes/state.py
+++ b/core/routes/state.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/state")
+async def get_state():
+    return {"user": "demo", "mood": "happy", "flags": {}, "memory": {}}
+
+@router.get("/state/memory")
+async def get_memory_state():
+    return {"flags": {}, "memory": {}}
+
+@router.get("/state/memory/chain/{user}")
+async def get_memory_chain(user: str):
+    return []
+
+@router.delete("/state/memory/{key}")
+async def delete_memory_value(key: str):
+    return {"status": "deleted"}

--- a/core/routes/system.py
+++ b/core/routes/system.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Response
+from fastapi.responses import StreamingResponse
+from io import BytesIO
+
+router = APIRouter()
+
+@router.get("/system/state")
+async def system_state():
+    return {"mode": "dev", "flags": {}, "memory": {}}
+
+@router.post("/system/mode")
+async def set_system_mode(mode: str):
+    return {"status": "ok", "mode": mode}
+
+@router.get("/core/status")
+async def core_status():
+    return {"status": "ok"}
+
+@router.post("/core/safe-mode/toggle")
+async def toggle_safe_mode():
+    return {"status": "ok"}
+
+@router.get("/system/memory/{user}")
+async def user_memory(user: str):
+    return {"user": user, "memory": []}
+
+@router.get("/system/dashboard")
+async def dashboard_summary():
+    return {"safe_mode": False, "active_agents": [], "registered_agents": [], "memory_key_counts": {}}
+
+@router.get("/system/export/pdf/{user}")
+async def export_user_memory_pdf(user: str):
+    pdf_bytes = BytesIO(b"PDF data for " + user.encode())
+    return StreamingResponse(pdf_bytes, media_type="application/pdf")

--- a/core/routes/users.py
+++ b/core/routes/users.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/users")
+async def list_users(page: int = 1, per_page: int = 20, role: str | None = None):
+    return {"users": [], "total": 0, "page": page, "per_page": per_page}
+
+@router.get("/users/{user_id}")
+async def get_user(user_id: str):
+    return {"id": user_id, "username": "demo", "email": "demo@example.com", "role": "user", "verified": True}
+
+@router.put("/users/{user_id}")
+async def update_user(user_id: str, data: dict):
+    updated = {"id": user_id}
+    updated.update(data)
+    return updated
+
+@router.delete("/users/{user_id}")
+async def delete_user(user_id: str):
+    return {"status": "deleted", "message": f"User {user_id} removed"}

--- a/core/routes/verify.py
+++ b/core/routes/verify.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post("/verify")
+async def verify_code(data: dict):
+    return {"success": True}
+
+@router.post("/verify/setup")
+async def verify_setup():
+    return {"secret": "secret", "uri": "uri", "qr_code": "qr"}
+
+@router.get("/verify/stats")
+async def verify_stats():
+    return {"success_count": 0, "failure_count": 0, "locked_users": 0, "timestamp": "now"}

--- a/main.py
+++ b/main.py
@@ -7,6 +7,21 @@ from core.config.settings import settings
 from core.cache.redis_cache import connect_redis, close_redis
 from db.database import connect_db, close_db
 from core.routes.health import router as health_router
+from core.routes.auth import router as auth_router
+from core.routes.users import router as users_router
+from core.routes.system import router as system_router
+from core.routes.logs import router as logs_router
+from core.routes.feedback import router as feedback_router
+from core.routes.query import router as query_router
+from core.routes.rootbloom import router as rootbloom_router
+from core.routes.neuroweave import router as neuroweave_router
+from core.routes.sporelink import router as sporelink_router
+from core.routes.verify import router as verify_router
+from core.routes.database import router as database_router
+from core.routes.plugins import router as plugins_router
+from core.routes.mycocore import router as mycocore_router
+from core.routes.state import router as state_router
+from core.routes.agents import router as agents_router
 
 # Prefix for all API routes
 API_PREFIX = "/api"
@@ -34,6 +49,23 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-routers = [health_router]
+routers = [
+    health_router,
+    auth_router,
+    users_router,
+    system_router,
+    logs_router,
+    feedback_router,
+    query_router,
+    rootbloom_router,
+    neuroweave_router,
+    sporelink_router,
+    verify_router,
+    database_router,
+    plugins_router,
+    mycocore_router,
+    state_router,
+    agents_router,
+]
 for router in routers:
     app.include_router(router, prefix=API_PREFIX)


### PR DESCRIPTION
## Summary
- implement stub routers for API endpoints referenced by the frontend
- register all routers in the FastAPI application

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pydantic_settings`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686642f48f70832ca2c6ac00b994c61b