### PR TITLE
Add User model and DB-backed auth

### DIFF
--- a/core/routes/auth.py
+++ b/core/routes/auth.py
@@ -1,22 +1,58 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+import bcrypt
+
+from db.database import get_db
+from db.models import User
 
 router = APIRouter()
 
 @router.post("/auth/register")
-async def register_user(data: dict):
-    return {"status": "registered", "user": data}
+async def register_user(data: dict, db: AsyncSession = Depends(get_db)):
+    username = data.get("username")
+    password = data.get("password")
+    email = data.get("email")
+
+    if not username or not password:
+        raise HTTPException(status_code=400, detail="Username and password required")
+
+    result = await db.execute(select(User).where(User.username == username))
+    if result.scalar_one_or_none():
+        raise HTTPException(status_code=400, detail="Username already exists")
+
+    hashed_pw = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    user = User(username=username, email=email, hashed_password=hashed_pw)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return {"id": user.id, "username": user.username, "email": user.email}
 
 @router.post("/auth/login")
-async def login_user(credentials: dict):
-    return {"id": 1, "username": credentials.get("username"), "role": "user", "token": "fake-token", "pin_verified": True}
+async def login_user(credentials: dict, db: AsyncSession = Depends(get_db)):
+    username = credentials.get("username")
+    password = credentials.get("password")
+
+    if not username or not password:
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+
+    result = await db.execute(select(User).where(User.username == username))
+    user = result.scalar_one_or_none()
+    if not user or not bcrypt.checkpw(password.encode(), user.hashed_password.encode()):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    return {"id": user.id, "username": user.username, "role": "user", "token": "fake-token", "pin_verified": True}
 
 @router.post("/auth/logout")
 async def logout_user():
     return {"status": "logged_out"}
 
 @router.get("/auth/me")
-async def get_profile():
-    return {"id": 1, "username": "demo", "email": "demo@example.com", "role": "user", "verified": True}
+async def get_profile(user_id: int = 1, db: AsyncSession = Depends(get_db)):
+    user = await db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"id": user.id, "username": user.username, "email": user.email, "role": "user", "verified": True}
 
 @router.post("/auth/refresh")
 async def refresh_token():
@@ -43,8 +79,11 @@ async def verify_email(token: str = Query(...)):
     return {"message": "Email verified"}
 
 @router.get("/auth/status")
-async def auth_status():
-    return {"status": "authenticated", "username": "demo", "role": "user"}
+async def auth_status(user_id: int = 1, db: AsyncSession = Depends(get_db)):
+    user = await db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"status": "authenticated", "username": user.username, "role": "user"}
 
 @router.get("/auth/admin_only")
 async def admin_only():

--- a/db/database.py
+++ b/db/database.py
@@ -1,6 +1,7 @@
 # database.py
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.orm import declarative_base
+
 from core.config.settings import settings
 
 engine = create_async_engine(settings.DATABASE_URL, echo=False, future=True)
@@ -12,6 +13,9 @@ async def get_db():
         yield session
 
 async def connect_db():
+    # Import models here so Base has all metadata before creating tables
+    from . import models  # noqa: F401
+
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -1,0 +1,3 @@
+from .user import User
+
+__all__ = ["User"]

--- a/db/models/user.py
+++ b/db/models/user.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime
+from sqlalchemy.sql import func
+
+from db.database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(50), unique=True, index=True, nullable=False)
+    email = Column(String(100), unique=True, index=True, nullable=True)
+    hashed_password = Column(String(128), nullable=False)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,9 @@ fastapi
 uvicorn[standard]
 redis[asyncio]
 pydantic
+pydantic-settings
 sqlalchemy
 asyncpg
 python-dotenv
 alembic
+bcrypt


### PR DESCRIPTION
## Summary
- create `User` SQLAlchemy model under `db/models`
- initialize models in database connection
- hash passwords with `bcrypt`
- implement user registration, login and profile endpoints to use async DB
- update requirements for `pydantic-settings` and `bcrypt`

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68664761dbd0832caad27a1c89bfd864