### PR TITLE
Add email utility with SMTP support

### DIFF
--- a/core/config/settings.py
+++ b/core/config/settings.py
@@ -4,6 +4,10 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     REDIS_URL: str
     DATABASE_URL: str
+    SMTP_HOST: str = "smtp.gmail.com"
+    SMTP_PORT: int = 587
+    SMTP_USER: str = ""
+    SMTP_PASSWORD: str = ""
 
     class Config:
         env_file = ".env"

--- a/core/routes/auth.py
+++ b/core/routes/auth.py
@@ -3,6 +3,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 import bcrypt
 
+from core.utils import send_email
+
 from db.database import get_db
 from db.models import User
 
@@ -26,6 +28,12 @@ async def register_user(data: dict, db: AsyncSession = Depends(get_db)):
     db.add(user)
     await db.commit()
     await db.refresh(user)
+    if email:
+        await send_email(
+            email,
+            "Verify your email",
+            f"Hello {username}, please verify your email address.",
+        )
     return {"id": user.id, "username": user.username, "email": user.email}
 
 @router.post("/auth/login")
@@ -91,6 +99,11 @@ async def admin_only():
 
 @router.post("/auth/password-reset/request")
 async def password_reset_request(email: str):
+    await send_email(
+        email,
+        "Password Reset",
+        "Follow this link to reset your password.",
+    )
     return {"message": "Reset email sent"}
 
 @router.post("/auth/password-reset/verify")

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,0 +1,1 @@
+from .email import send_email

--- a/core/utils/email.py
+++ b/core/utils/email.py
@@ -1,0 +1,21 @@
+import aiosmtplib
+from email.message import EmailMessage
+
+from core.config.settings import settings
+
+async def send_email(recipient: str, subject: str, body: str) -> None:
+    """Send an email using the configured SMTP server."""
+    message = EmailMessage()
+    message["From"] = settings.SMTP_USER
+    message["To"] = recipient
+    message["Subject"] = subject
+    message.set_content(body)
+
+    await aiosmtplib.send(
+        message,
+        hostname=settings.SMTP_HOST,
+        port=settings.SMTP_PORT,
+        username=settings.SMTP_USER,
+        password=settings.SMTP_PASSWORD,
+        start_tls=True,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ asyncpg
 python-dotenv
 alembic
 bcrypt
+aiosmtplib


### PR DESCRIPTION
## Summary
- add Gmail SMTP config options
- implement async email helper using `aiosmtplib`
- send email when a user registers or requests password reset
- expose `send_email` from `core.utils`
- include `aiosmtplib` in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664c958b6c832cb45621ae498ed9b6