### PR TITLE
Use safe parser for alert rules

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "d3-array": "^3.2.4",
         "date-fns-tz": "^3.2.0",
         "framer-motion": "^12.23.0",
+        "jexl": "^2.3.0",
         "lucide-react": "^0.525.0",
         "postcss": "^8.5.6",
         "react": "^19.1.0",
@@ -33,6 +34,7 @@
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@types/d3-array": "^3.2.1",
+        "@types/jexl": "^2.3.4",
         "@types/node": "^24.0.10",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -293,6 +295,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2264,6 +2275,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jexl": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/jexl/-/jexl-2.3.4.tgz",
+      "integrity": "sha512-3BU5DbkPvwqOeW8kZcB9Bvn5bspTFY3Lo0yBS6ephuI8kVSpCjzbGtRPbWnvdbr67tMvXDxiJRcL3fwbz/6+PQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4995,6 +5013,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jexl": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jexl/-/jexl-2.3.0.tgz",
+      "integrity": "sha512-ecqln4kTWNkMwbFvTukOMDq1jy1GcPzvshhMp/s4pxU86xdLDq7HbDRa87DfMfbSAOS8V6EwvCdfs0S+w/iycA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.10.2"
       }
     },
     "node_modules/jiti": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "d3-array": "^3.2.4",
     "date-fns-tz": "^3.2.0",
     "framer-motion": "^12.23.0",
+    "jexl": "^2.3.0",
     "lucide-react": "^0.525.0",
     "postcss": "^8.5.6",
     "react": "^19.1.0",
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@types/d3-array": "^3.2.1",
+    "@types/jexl": "^2.3.4",
     "@types/node": "^24.0.10",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/frontend/src/lib/alerts/AlertManager.ts
+++ b/frontend/src/lib/alerts/AlertManager.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { toast } from "react-toastify";
+import jexl from "jexl";
 
 export interface AlertRule {
   id: string;
@@ -63,10 +64,12 @@ export const useAlertStore = create<AlertStore>((set, get) => ({
           ...data,
         };
 
-        const result = new Function(
-          ...Object.keys(context),
-          `return ${rule.condition}`,
-        )(...Object.values(context));
+        if (typeof rule.condition !== "string" || !rule.condition.trim()) {
+          console.error("Invalid rule condition");
+          return;
+        }
+
+        const result = jexl.evalSync(rule.condition, context);
 
         if (result) {
           const timestamp = new Date().toLocaleTimeString();


### PR DESCRIPTION
## Summary
- remove `new Function` call from AlertManager
- add `jexl` expression parser
- validate rule condition before evaluation
- add typings for jexl

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686665dbbbb8832cb1168743badbcc02