### PR TITLE
Improve connection resilience

### DIFF
--- a/core/cache/redis_cache.py
+++ b/core/cache/redis_cache.py
@@ -1,20 +1,51 @@
 # redis_cache.py
 import redis.asyncio as aioredis
 from core.config.settings import settings
+from core.utils.logger import get_logger
+import asyncio
+
+logger = get_logger(__name__)
 
 redis = None  # Global Redis connection
 
-async def connect_redis():
+async def connect_redis(max_retries: int = 3, delay: float = 2.0) -> bool:
+    """Establish connection to Redis.
+
+    Parameters
+    ----------
+    max_retries: int
+        Number of connection attempts before giving up.
+    delay: float
+        Delay between retries in seconds.
+
+    Returns
+    -------
+    bool
+        True if connection succeeded, False otherwise.
+    """
     global redis
-    redis = aioredis.from_url(
-        settings.REDIS_URL,
-        decode_responses=True,
-        max_connections=10,
-        socket_connect_timeout=5,
-    )
+    for attempt in range(1, max_retries + 1):
+        try:
+            redis = aioredis.from_url(
+                settings.REDIS_URL,
+                decode_responses=True,
+                max_connections=10,
+                socket_connect_timeout=5,
+            )
+            await redis.ping()
+            logger.info("Connected to Redis")
+            return True
+        except Exception as exc:
+            logger.error(f"Redis connection attempt {attempt} failed: {exc}")
+            redis = None
+            if attempt == max_retries:
+                logger.error("All Redis connection attempts failed; continuing without cache")
+                return False
+            await asyncio.sleep(delay)
 
 async def close_redis():
     global redis
     if redis:
         await redis.aclose()
         redis = None
+        logger.info("Redis connection closed")

--- a/db/database.py
+++ b/db/database.py
@@ -3,6 +3,10 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.orm import declarative_base
 
 from core.config.settings import settings
+from core.utils.logger import get_logger
+import asyncio
+
+logger = get_logger(__name__)
 
 engine = create_async_engine(settings.DATABASE_URL, echo=False, future=True)
 AsyncSessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False)
@@ -12,12 +16,37 @@ async def get_db():
     async with AsyncSessionLocal() as session:
         yield session
 
-async def connect_db():
-    # Import models here so Base has all metadata before creating tables
+async def connect_db(max_retries: int = 3, delay: float = 2.0) -> bool:
+    """Connect to the database and create tables.
+
+    Parameters
+    ----------
+    max_retries: int
+        Number of connection attempts before giving up.
+    delay: float
+        Delay in seconds between retries.
+
+    Returns
+    -------
+    bool
+        True if connection succeeded, False otherwise.
+    """
     from . import models  # noqa: F401
 
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    for attempt in range(1, max_retries + 1):
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
+            logger.info("Database connection established")
+            return True
+        except Exception as exc:
+            logger.error(f"Database connection attempt {attempt} failed: {exc}")
+            if attempt == max_retries:
+                logger.error("All database connection attempts failed; running in degraded mode")
+                return False
+            await asyncio.sleep(delay)
+
 
 async def close_db():
     await engine.dispose()
+    logger.info("Database connection closed")


### PR DESCRIPTION
## Summary
- add logging and retry loops for DB and Redis connections
- continue startup if connections fail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68666730e5d0832ca854e32a3067c158