### PR TITLE
Add Pydantic schemas for auth

### DIFF
--- a/core/routes/auth.py
+++ b/core/routes/auth.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import bcrypt
 
 from core.utils import send_email
+from core.schemas import UserCreate, UserLogin
 
 from db.database import get_db
 from db.models import User
@@ -11,10 +12,10 @@ from db.models import User
 router = APIRouter()
 
 @router.post("/auth/register")
-async def register_user(data: dict, db: AsyncSession = Depends(get_db)):
-    username = data.get("username")
-    password = data.get("password")
-    email = data.get("email")
+async def register_user(data: UserCreate, db: AsyncSession = Depends(get_db)):
+    username = data.username
+    password = data.password
+    email = data.email
 
     if not username or not password:
         raise HTTPException(status_code=400, detail="Username and password required")
@@ -37,9 +38,9 @@ async def register_user(data: dict, db: AsyncSession = Depends(get_db)):
     return {"id": user.id, "username": user.username, "email": user.email}
 
 @router.post("/auth/login")
-async def login_user(credentials: dict, db: AsyncSession = Depends(get_db)):
-    username = credentials.get("username")
-    password = credentials.get("password")
+async def login_user(credentials: UserLogin, db: AsyncSession = Depends(get_db)):
+    username = credentials.username
+    password = credentials.password
 
     if not username or not password:
         raise HTTPException(status_code=400, detail="Invalid credentials")

--- a/core/schemas/__init__.py
+++ b/core/schemas/__init__.py
@@ -1,0 +1,2 @@
+from .user import UserCreate, UserLogin
+__all__ = ["UserCreate", "UserLogin"]

--- a/core/schemas/user.py
+++ b/core/schemas/user.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+    email: Optional[str] = None
+
+class UserLogin(BaseModel):
+    username: str
+    password: str

--- a/test/redis_test.py
+++ b/test/redis_test.py
@@ -1,3 +1,7 @@
+import os
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
 import asyncio
 from core.cache.redis_cache import connect_redis, close_redis
 

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -1,3 +1,6 @@
+import os
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
 import asyncio
 from db.database import connect_db, close_db, get_db
 


### PR DESCRIPTION
## Summary
- create `core/schemas` with `UserCreate` and `UserLogin`
- update auth routes to use Pydantic models
- adjust tests for new schemas
- add minimal environment setup in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866683d87bc832cbe3be0e0cd9d0c66