### PR TITLE
Add email verification workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USER=your-email@example.com
 SMTP_PASSWORD=your-email-password
+FRONTEND_URL=http://localhost:5173

--- a/core/config/settings.py
+++ b/core/config/settings.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     SMTP_PORT: int = 587
     SMTP_USER: str = ""
     SMTP_PASSWORD: str = ""
+    FRONTEND_URL: str = "http://localhost:5173"
 
     class Config:
         env_file = ".env"

--- a/db/models/user.py
+++ b/db/models/user.py
@@ -11,4 +11,6 @@ class User(Base):
     email = Column(String(100), unique=True, index=True, nullable=True)
     hashed_password = Column(String(128), nullable=False)
     is_active = Column(Boolean, default=True)
+    is_verified = Column(Boolean, default=False)
+    verification_token = Column(String(128), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/test/test_auth_routes.py
+++ b/test/test_auth_routes.py
@@ -23,15 +23,17 @@ async def test_register_user_success():
     db.refresh = AsyncMock(side_effect=refresh)
     db.commit = AsyncMock()
 
-    with patch('core.routes.auth.send_email', new=AsyncMock()) as mock_send:
-        user_in = UserCreate(username='alice', password='secret', email='alice@example.com')
-        resp = await auth.register_user(user_in, db=db)
-        assert resp == {'id': 1, 'username': 'alice', 'email': 'alice@example.com'}
-        mock_send.assert_awaited_once_with(
-            'alice@example.com',
-            'Verify your email',
-            'Hello alice, please verify your email address.'
-        )
+    with patch('core.routes.auth.secrets.token_urlsafe', return_value='tok123'):
+        with patch('core.routes.auth.send_email', new=AsyncMock()) as mock_send:
+            user_in = UserCreate(username='alice', password='secret', email='alice@example.com')
+            resp = await auth.register_user(user_in, db=db)
+            assert resp == {'id': 1, 'username': 'alice', 'email': 'alice@example.com'}
+            verify_link = f"http://localhost:5173/verify-email?token=tok123&email=alice@example.com"
+            mock_send.assert_awaited_once_with(
+                'alice@example.com',
+                'Verify your email',
+                f'Hello alice, please verify your email by visiting {verify_link}'
+            )
     db.add.assert_called()
     db.commit.assert_called()
     db.refresh.assert_called()
@@ -61,3 +63,19 @@ async def test_send_email_dispatch():
         message = mock_send.call_args.args[0]
         assert message['To'] == 'bob@example.com'
         assert message['Subject'] == 'Hi'
+
+
+@pytest.mark.asyncio
+async def test_verify_email_success():
+    user = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = user
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+    db.commit = AsyncMock()
+
+    resp = await auth.verify_email(token='tok123', db=db)
+    assert resp == {'message': 'Email verified'}
+    assert user.is_verified is True
+    assert user.verification_token is None
+    db.commit.assert_called()


### PR DESCRIPTION
## Summary
- store email verification info on User model
- send verification link on register
- implement `/auth/verify_email`
- expose `FRONTEND_URL` in config and `.env.example`
- update tests

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pip install -q aiosqlite`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686675171634832c9b5fa912b35a669a