### PR TITLE
Fix resend email verification body

### DIFF
--- a/core/routes/auth.py
+++ b/core/routes/auth.py
@@ -136,7 +136,7 @@ async def password_reset_verify(token: str, new_password: str):
 
 @router.post("/auth/resend-verification")
 async def resend_verification(
-    email: str = Body(...),
+    email: str = Body(..., embed=True),
     db: AsyncSession = Depends(get_db),
 ):
     result = await db.execute(select(User).where(User.email == email))


### PR DESCRIPTION
## Summary
- fix body parsing for `/auth/resend-verification`

## Testing
- `pytest -q` *(fails: No module named 'redis', 'bcrypt', 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68669ac1f504832c8a7ac3a990953d21