### PR TITLE
Fix resend email verification body

### DIFF
--- a/core/routes/auth.py
+++ b/core/routes/auth.py
@@ -136,7 +136,7 @@ async def password_reset_verify(token: str, new_password: str):
 
 @router.post("/auth/resend-verification")
 async def resend_verification(
-    email: str = Body(...),
+    email: str = Body(..., embed=True),
     db: AsyncSession = Depends(get_db),
 ):
     result = await db.execute(select(User).where(User.email == email))

--- a/frontend/src/components/auth/EmailVerificationPanel.tsx
+++ b/frontend/src/components/auth/EmailVerificationPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
 
@@ -18,9 +18,12 @@ const EmailVerificationPanel: React.FC = () => {
   const [status, setStatus] = useState<"idle" | "pending" | "success" | "error">(
     token ? "pending" : "idle"
   );
+  const attemptedRef = useRef(false);
 
-  // Attempt auto-verification if token is present
+  // Attempt auto-verification if token is present (guard against Strict Mode double-run)
   useEffect(() => {
+    if (attemptedRef.current) return;
+    attemptedRef.current = true;
     if (!email) {
       setMessage("No email found. Please register or login.");
       setTimeout(() => navigate("/login", { replace: true }), 2500);

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -92,9 +92,14 @@ function useProvideAuth(): AuthContextType {
     try {
       const res: AuthResult = await loginService({ username, password, code });
       setToken(res.token);
-      const me = await getProfile();
-      setUser(me);
-      return me;
+      const loginUser: User = {
+        id: res.id,
+        username: res.username,
+        role: res.role,
+        pin_verified: res.pin_verified,
+      };
+      setUser(loginUser);
+      return loginUser;
     } catch (e: any) {
       setError(e.message);
       throw e;


### PR DESCRIPTION
## Summary
- fix body parsing for `/auth/resend-verification`
- prevent double verification requests in React Strict Mode
- avoid unnecessary profile fetch after login

## Testing
- `pytest -q` *(fails: No module named 'redis', 'bcrypt', 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68669ac1f504832c8a7ac3a990953d21