### PR TITLE
Fix email verification flow

### DIFF
--- a/frontend/src/components/auth/EmailVerificationPanel.tsx
+++ b/frontend/src/components/auth/EmailVerificationPanel.tsx
@@ -30,7 +30,7 @@ const EmailVerificationPanel: React.FC = () => {
       setStatus("pending");
       setMessage("Verifying your email...");
       axios
-        .get("/api/auth/verify_email", { params: { token } })
+        .get("/api/auth/verify_email", { params: { token, email } })
         .then(res => {
           setStatus("success");
           setMessage(res.data.message || "Email verified! You may now log in.");

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -122,8 +122,11 @@ export async function changePin(old_pin: string, new_pin: string): Promise<{ suc
  * Verify a user’s email address via token.
  * GET /auth/verify_email?token={token}
  */
-export async function verifyEmail(token: string): Promise<{ message: string }> {
-  const res = await api.get<{ message: string }>(`/auth/verify_email?token=${encodeURIComponent(token)}`);
+export async function verifyEmail(token: string, email?: string): Promise<{ message: string }> {
+  const params: Record<string, string> = { token };
+  if (email) params.email = email;
+  const query = new URLSearchParams(params).toString();
+  const res = await api.get<{ message: string }>(`/auth/verify_email?${query}`);
   return res.data;
 }
 


### PR DESCRIPTION
## Summary
- require email verification before login
- return `Email already verified` when hitting the verify endpoint with an already used token
- pass the email along when verifying from the frontend
- adjust unit tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68679e6065e4832cbd3eda1e75835ab0