### PR TITLE
Improve dashboard styling

### DIFF
--- a/frontend/src/components/dashboard/panels/MarketDashboard/AlertRulesPanel.tsx
+++ b/frontend/src/components/dashboard/panels/MarketDashboard/AlertRulesPanel.tsx
@@ -19,7 +19,7 @@ export default function AlertRulesPanel() {
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-sm p-6 mb-6">
+    <div className="bg-dark-200 rounded-lg shadow-sm p-6 mb-6 border border-dark-100/50 text-white">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-lg font-semibold">Alert Rules</h2>
         <button

--- a/frontend/src/components/dashboard/panels/MarketDashboard/ChartPanel.tsx
+++ b/frontend/src/components/dashboard/panels/MarketDashboard/ChartPanel.tsx
@@ -119,7 +119,7 @@ const ChartPanel: React.FC<ChartPanelProps> = ({
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-sm p-6">
+    <div className="bg-dark-200 rounded-lg shadow-sm p-6 border border-dark-100/50 text-white">
       {/* Indicator selection UI */}
       <div className="mb-4 flex flex-wrap gap-2">
         {Object.values(indicatorsRegistry).map((ind) => (

--- a/frontend/src/components/dashboard/panels/MarketDashboard/IndexTicker.tsx
+++ b/frontend/src/components/dashboard/panels/MarketDashboard/IndexTicker.tsx
@@ -7,11 +7,11 @@ interface Props {
 
 export default function IndexTicker({ indices }: Props) {
   return (
-    <div className="bg-white rounded-lg shadow-sm p-4 mb-6">
+    <div className="bg-dark-200 rounded-lg shadow-sm p-4 mb-6 border border-dark-100/50 text-white">
       <div className="grid grid-cols-3 gap-4">
         {Object.entries(indices).map(([symbol, data]) => (
-          <div key={symbol} className={`text-center ${symbol!=="^DJI"?"border-l border-gray-200":""}`}>
-            <div className="text-sm text-gray-500">
+          <div key={symbol} className={`text-center ${symbol!=="^DJI"?"border-l border-dark-100/50":""}`}>
+            <div className="text-sm text-gray-400">
               {symbol==="^DJI"?"Dow Jones":symbol==="^GSPC"?"S&P 500":"Nasdaq"}
             </div>
             <div className="text-xl font-semibold">

--- a/frontend/src/components/dashboard/panels/MarketDashboard/NewsPanel.tsx
+++ b/frontend/src/components/dashboard/panels/MarketDashboard/NewsPanel.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export default function NewsPanel({ news, filter, setFilter }: Props) {
   return (
-    <div className="bg-white rounded-lg shadow-sm p-6">
+    <div className="bg-dark-200 rounded-lg shadow-sm p-6 border border-dark-100/50 text-white">
       <div className="flex justify-between mb-4">
         <h2 className="text-lg font-semibold flex items-center gap-2">
           <Newspaper /> Market News

--- a/frontend/src/components/dashboard/panels/MarketDashboard/PDFInsights.tsx
+++ b/frontend/src/components/dashboard/panels/MarketDashboard/PDFInsights.tsx
@@ -16,7 +16,7 @@ interface Props {
 export default function PDFInsights({ insights, showModal, selectedFile, onFileChange, onUpload, status, onClose }: Props) {
   return (
     <div>
-      <div className="bg-white rounded-lg shadow-sm p-6">
+      <div className="bg-dark-200 rounded-lg shadow-sm p-6 border border-dark-100/50 text-white">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold">PDF Insights</h2>
           <button onClick={()=>onClose()} className="text-indigo-600 flex items-center gap-1">
@@ -40,7 +40,7 @@ export default function PDFInsights({ insights, showModal, selectedFile, onFileC
 
       {showModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full">
+          <div className="bg-dark-200 rounded-lg p-6 max-w-md w-full border border-dark-100/50 text-white">
             <div className="flex justify-between mb-4">
               <h3 className="text-lg font-semibold">Upload PDF</h3>
               <button onClick={onClose}><X/></button>

--- a/frontend/src/components/dashboard/panels/MarketDashboard/TutorialOverlay.tsx
+++ b/frontend/src/components/dashboard/panels/MarketDashboard/TutorialOverlay.tsx
@@ -5,7 +5,7 @@ interface Props { isOpen:boolean; onClose:()=>void; }
 export default function TutorialOverlay({ isOpen, onClose }: Props) {
   if (!isOpen) return null;
   return (
-    <div className="fixed bottom-4 right-4 p-4 bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-md">
+    <div className="fixed bottom-4 right-4 p-4 bg-dark-200 rounded-lg shadow-lg max-w-md border border-dark-100/50 text-white">
       <h3 className="text-lg font-semibold mb-2">Market Terms</h3>
       <div className="space-y-2 text-sm">
         <p><strong>SMA:</strong> Simple Moving Average</p>

--- a/frontend/src/components/dashboard/panels/MarketDashboard/WatchlistTable.tsx
+++ b/frontend/src/components/dashboard/panels/MarketDashboard/WatchlistTable.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export default function WatchlistTable({ watchlist, searchTerm, setSearchTerm, onAddSymbol }: Props) {
   return (
-    <div className="bg-white rounded-lg shadow-sm p-6">
+    <div className="bg-dark-200 rounded-lg shadow-sm p-6 border border-dark-100/50 text-white">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-semibold">Watchlist</h2>
         <div className="flex gap-2">

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,9 @@ import ReactDOM from "react-dom/client";
 import App from "./app";
 import "./index.css";
 
+// Enable dark theme by default
+document.documentElement.classList.add("dark");
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- default to dark mode
- restyle MarketDashboard panels with dark theme backgrounds

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_6867a209149c832c8a30ea1ac6195d43