### PR TITLE
Add env example and improve location service

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ This repository contains the HyphaeOS backend and frontend.
    ```bash
    pip install -r requirements.txt
    ```
-2. Copy `.env.example` to `.env` and fill in the real credentials for Redis, the database and SMTP:
+2. Copy `.env.example` to `.env` and fill in the real credentials for Redis, the database and SMTP. Also copy `frontend/.env.example` to `frontend/.env` and set the API keys used by the dashboard widgets:
    ```bash
    cp .env.example .env
-   # then edit .env
+   cp frontend/.env.example frontend/.env
+   # then edit .env and frontend/.env
    ```
 3. Run the application:
    ```bash

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Frontend environment variables
+VITE_OPENCAGE_API_KEY=your-opencage-api-key
+VITE_WEATHER_API_KEY=your-weather-api-key

--- a/frontend/src/services/location.ts
+++ b/frontend/src/services/location.ts
@@ -52,9 +52,14 @@ class LocationService {
       const position = await this.getCurrentPosition();
       const { latitude, longitude } = position.coords;
 
+      const key = import.meta.env.VITE_OPENCAGE_API_KEY;
+      if (!key) {
+        throw new Error('VITE_OPENCAGE_API_KEY is missing');
+      }
+
       // Use reverse geocoding to get location details
       const response = await axios.get(
-        `https://api.opencagedata.com/geocode/v1/json?q=${latitude}+${longitude}&key=${import.meta.env.VITE_OPENCAGE_API_KEY}`,
+        `https://api.opencagedata.com/geocode/v1/json?q=${latitude}+${longitude}&key=${key}`,
       );
 
       const result = response.data.results[0];
@@ -81,8 +86,13 @@ class LocationService {
     }
 
     try {
+      const weatherKey = import.meta.env.VITE_WEATHER_API_KEY;
+      if (!weatherKey) {
+        throw new Error('VITE_WEATHER_API_KEY is missing');
+      }
+
       const response = await axios.get(
-        `https://api.weatherapi.com/v1/forecast.json?key=${import.meta.env.VITE_WEATHER_API_KEY}&q=${this.currentLocation.latitude},${this.currentLocation.longitude}&days=5`,
+        `https://api.weatherapi.com/v1/forecast.json?key=${weatherKey}&q=${this.currentLocation.latitude},${this.currentLocation.longitude}&days=5`,
       );
 
       return {


### PR DESCRIPTION
## Summary
- add frontend `.env.example` documenting weather API keys
- mention the new env file in the setup instructions
- make `locationService` throw helpful errors when API keys are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_68683ed46abc832c951fcc8dde4cf8ed