### PR TITLE
Remove right side alert panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ This repository contains the HyphaeOS backend and frontend.
    ```bash
    python main.py
    ```
+
+## Dashboard Notes
+
+The overview page previously displayed a right-side alerts panel with a logout
+button. This panel has been removed. A future improvement could be a
+terminal-style log feed similar to the authentication screens to surface system
+warnings and other activity.

--- a/frontend/src/components/dashboard/panels/Overview.tsx
+++ b/frontend/src/components/dashboard/panels/Overview.tsx
@@ -114,36 +114,13 @@ const Overview: React.FC<OverviewProps> = ({ onLogout }) => {
         variants={containerVariants}
         initial="hidden"
         animate="visible"
-        className="grid grid-cols-1 lg:grid-cols-2 gap-6"
+        className="grid grid-cols-1 gap-6"
       >
         <motion.div variants={itemVariants}>
           <RecentActivity />
         </motion.div>
 
-        <motion.div variants={itemVariants} className="bg-dark-200/80 backdrop-blur-sm rounded-xl p-6 border border-dark-100/50 shadow-lg">
-          <div className="flex justify-end mb-4">
-            <button
-              onClick={onLogout}
-              className="text-sm px-4 py-2 rounded-lg bg-error-500/20 hover:bg-error-500/30 text-error-300 transition-colors"
-            >
-              Logout
-            </button>
-          </div>
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="text-lg font-semibold text-white">System Alerts</h2>
-            <span className={`rounded-full px-2 py-1 text-xs font-medium ${
-                systemStatus.warnings > 0
-                  ? "bg-warning-500/20 text-warning-300"
-                  : "bg-success-500/20 text-success-300"
-              }`}
-            >
-              {systemStatus.warnings} Warnings
-            </span>
-          </div>
-          <div className="space-y-3">
-            {/* Add your alert cards or items here */}
-          </div>
-        </motion.div>
+        {/* TODO: Replace removed alert panel with terminal-style log feed */}
       </motion.div>
     </div>
   );


### PR DESCRIPTION
## Summary
- clean up Overview panel layout by removing unused alert column
- add dashboard note to README suggesting a future terminal-style log feed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_6868730c0be0832c837290bf554f2c19