### PR TITLE
Refactor navigation for agent-specific panels

### DIFF
--- a/frontend/src/agents/Neuroweave.tsx
+++ b/frontend/src/agents/Neuroweave.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Button from "@/components/ui/Button";
 import { useNeuroweave } from "@/hooks/useNeuroweave";
+import PredictiveModels from "@/components/dashboard/panels/PredictiveModels";
 
 const Neuroweave: React.FC = () => {
   const { response, ask, loading, error } = useNeuroweave();
+  const [view, setView] = useState<"chat" | "models">("chat");
 
   // Initial prompt (empty prompt triggers default behavior)
   useEffect(() => {
@@ -12,29 +14,35 @@ const Neuroweave: React.FC = () => {
 
   return (
     <div className="bg-dark-200 p-6 rounded-2xl shadow-inner border border-hyphae-500/20 text-white">
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-bold text-hyphae-300">🧠 Neuroweave Panel</h2>
-        <Button
-          onClick={() => ask("")}
-          className="bg-hyphae-500 hover:bg-hyphae-600 text-white"
-        >
-          Refresh Threads
-        </Button>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-bold text-hyphae-300">🧠 Neuroweave</h2>
+        <div className="space-x-2">
+          <Button variant={view === "chat" ? "primary" : "ghost"} size="sm" onClick={() => setView("chat")}>Chat</Button>
+          <Button variant={view === "models" ? "primary" : "ghost"} size="sm" onClick={() => setView("models")}>Predictive Models</Button>
+          <Button
+            onClick={() => ask("")}
+            className="bg-hyphae-500 hover:bg-hyphae-600 text-white ml-2"
+            size="sm"
+          >
+            Refresh
+          </Button>
+        </div>
       </div>
 
-      {loading && (
-        <p className="mb-4 text-hyphae-300">Loading neural threads…</p>
+      {view === "chat" && (
+        <>
+          {loading && <p className="mb-4 text-hyphae-300">Loading neural threads…</p>}
+          {error && (
+            <div className="mb-4 p-4 rounded bg-fungal-500/10 border border-fungal-500 text-fungal-300">
+              {error}
+            </div>
+          )}
+          <pre className="whitespace-pre-wrap max-h-[50vh] overflow-auto text-sm bg-dark-300 p-4 rounded-lg border border-hyphae-500/10">
+            {response}
+          </pre>
+        </>
       )}
-
-      {error && (
-        <div className="mb-4 p-4 rounded bg-fungal-500/10 border border-fungal-500 text-fungal-300">
-          {error}
-        </div>
-      )}
-
-      <pre className="whitespace-pre-wrap max-h-[50vh] overflow-auto text-sm bg-dark-300 p-4 rounded-lg border border-hyphae-500/10">
-        {response}
-      </pre>
+      {view === "models" && <PredictiveModels />}
     </div>
   );
 };

--- a/frontend/src/agents/Sporelink.tsx
+++ b/frontend/src/agents/Sporelink.tsx
@@ -1,5 +1,5 @@
 // src/agents/Sporelink.tsx
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { ArrowUpRight } from "lucide-react";
 import Card from "@/components/ui/StatusCard";
 import { useSporelink } from "@/hooks/useSporelink";
@@ -16,6 +16,7 @@ const Sporelink: React.FC = () => {
     fetchMarket,
     fetchNews,
   } = useSporelink();
+  const [view, setView] = useState<"dashboard" | "news">("dashboard");
 
   useEffect(() => {
     analyze("What’s the market outlook today?");
@@ -25,8 +26,24 @@ const Sporelink: React.FC = () => {
 
   return (
     <div className="space-y-8 p-6">
-      {/* ── Top‐level summary cards ───────────────────────── */}
-      <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      <div className="flex justify-end space-x-2">
+        <button
+          className={`px-3 py-1 rounded ${view === "dashboard" ? "bg-primary-500" : "bg-dark-300"}`}
+          onClick={() => setView("dashboard")}
+        >
+          Dashboard
+        </button>
+        <button
+          className={`px-3 py-1 rounded ${view === "news" ? "bg-primary-500" : "bg-dark-300"}`}
+          onClick={() => setView("news")}
+        >
+          News
+        </button>
+      </div>
+      {view === "dashboard" && (
+        <>
+        {/* ── Top‐level summary cards ───────────────────────── */}
+        <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {analysis && (
           <Card
             title="AI Analysis"
@@ -78,6 +95,18 @@ const Sporelink: React.FC = () => {
 
       {/* ── Full Market Dashboard ─────────────────────────── */}
       <MarketDashboard />
+      </>
+      )}
+      {view === "news" && (
+        <div className="space-y-4">
+          {news.map((n, i) => (
+            <a key={i} href={n.url} className="block p-4 rounded bg-dark-200 border border-dark-100/50 hover:bg-dark-100">
+              <h3 className="font-medium text-white">{n.title}</h3>
+              {n.source && <p className="text-xs text-gray-400">{n.source}</p>}
+            </a>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/dashboard/panels/Dashboard.tsx
+++ b/frontend/src/components/dashboard/panels/Dashboard.tsx
@@ -2,14 +2,21 @@ import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Navigation from "./Navigation";
 import Overview from "./Overview";
-import Agents from "./agents";
 import MemoryVault from "@/components/dashboard/panels/MemoryVault/index";
-import PredictiveModels from "./PredictiveModels";
 import Settings from "@/components/dashboard/panels/settings/SettingsIndex";
+import Neuroweave from "@/agents/Neuroweave";
+import Sporelink from "@/agents/Sporelink";
+import Rootbloom from "@/agents/Rootbloom";
 import { useAuth } from "@/hooks/useAuth";
 import ParticleBackground from "@/components/ui/ParticleBackground";
 
-type TabType = "overview" | "agents" | "memory" | "models" | "settings";
+type TabType =
+  | "overview"
+  | "neuroweave"
+  | "sporelink"
+  | "rootbloom"
+  | "memory"
+  | "settings";
 
 interface DashboardProps {
   onLogout: () => void;
@@ -21,9 +28,10 @@ const Dashboard: React.FC<DashboardProps> = ({ onLogout }) => {
 
   const tabComponents = {
     overview: <Overview onLogout={onLogout} />,
-    agents:   <Agents />,
-    memory:   <MemoryVault />,
-    models:   <PredictiveModels />,
+    neuroweave: <Neuroweave />,
+    sporelink: <Sporelink />,
+    rootbloom: <Rootbloom />,
+    memory: <MemoryVault />,
     settings: <Settings onLogout={onLogout} />,
   };
 

--- a/frontend/src/components/dashboard/panels/Navigation.tsx
+++ b/frontend/src/components/dashboard/panels/Navigation.tsx
@@ -5,7 +5,8 @@ import {
   LayoutDashboard,
   Users,
   Database,
-  LineChart,
+  Brain,
+  Flower2,
   Settings as SettingsIcon,
   LogOut,
   ChevronLeft,
@@ -32,9 +33,10 @@ const Navigation: React.FC<NavigationProps> = ({
 
   const navigationItems = [
     { id: "overview", label: "Overview", icon: <LayoutDashboard size={20} /> },
-    { id: "agents", label: "Agents", icon: <Users size={20} /> },
+    { id: "neuroweave", label: "Neuroweave", icon: <Brain size={20} /> },
+    { id: "sporelink", label: "Sporelink", icon: <Users size={20} /> },
+    { id: "rootbloom", label: "Rootbloom", icon: <Flower2 size={20} /> },
     { id: "memory", label: "Memory Vault", icon: <Database size={20} /> },
-    { id: "models", label: "Predictive Models", icon: <LineChart size={20} /> },
     { id: "settings", label: "Settings", icon: <SettingsIcon size={20} /> },
   ];
 


### PR DESCRIPTION
## Summary
- restructure dashboard navigation to show individual agents
- allow agent-specific pages for Neuroweave and Sporelink
- embed predictive models inside Neuroweave panel
- add simple news view under Sporelink

## Testing
- `pytest -q`
- `npm run lint` *(fails: module not found and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68687a1fcd5c832ca2c244ab043b03c3